### PR TITLE
add some code examples showing how to expose application metrics

### DIFF
--- a/docs/twisted.rst
+++ b/docs/twisted.rst
@@ -46,7 +46,58 @@ Decorator Wrappers
 Metric Exposure
 ---------------
 
-:doc:`TODO <future>`
+The underlying prometheus client libarary, `prometheus_client`_ exposes a `twisted.web.Resource`, namely `prometheus_client.twisted.MetricsResource`_, that makes it extremely easy to surface your metrics.
+
+     .. code-block:: python
+
+        from prometheus_client.twisted import MetricsResource
+        from twisted.web.server import Site
+        from twisted.web.resource import Resource
+        from twisted.internet import reactor
+
+        root = Resource()
+        root.putChild(b'metrics', MetricsResource())
+
+        factory = Site(root)
+        reactor.listenTCP(8000, factory)
+        reactor.run()
+
+As a slightly more in depth example, the following exposes the application's metrics under `/metrics` and sets up a `prometheus_client.Counter`_ for inbound HTTP requests.
+It also uses `Klein`_ to set up the routes instead of relying directly on `twisted.web`_ for routing.
+
+     .. code-block:: python
+
+        from prometheus_client.twisted import MetricsResource
+        from twisted.web.server import Site
+        from twisted.internet import reactor
+
+        from klein import Klein
+
+        from prometheus_client import Counter
+
+
+        INBOUND_REQUESTS = Counter(
+           'inbound_requests_total',
+           'Counter (int) of inbound http requests',
+           ['endpoint', 'method']
+        )
+
+        app = Klein()
+
+        @app.route('/metrics')
+        def metrics(request):
+            INBOUND_REQUESTS.labels('/metrics', 'GET').inc()
+            return MetricsResource()
+
+
+        factory = Site(app.resource())
+        reactor.listenTCP(8000, factory)
+        reactor.run()
+
 
 
 .. _twisted.web: https://twistedmatrix.com/documents/current/web/howto/web-in-60/index.html
+.. _prometheus_client: https://github.com/prometheus/client_python#twisted
+.. _prometheus_client.twisted.MetricsResource: https://github.com/prometheus/client_python/blob/master/prometheus_client/twisted/_exposition.py
+.. _prometheus_client.counter: https://github.com/prometheus/client_python#counter
+.. _klein: https://github.com/twisted/klein


### PR DESCRIPTION
This adds some documentation and examples about how to surface metrics for twisted using `prometheus_client`

But, _none_ of this is actually specific to `prometheus_async`, so I could certainly understand if you'd rather I open a PR/write a blog post elsewhere :). (The main reason I opened the PR here is I saw a TODO in the documentation).

Thanks for you work on this!