### PR TITLE
Minor fix to return appropriate 'time' for python 2

### DIFF
--- a/src/prometheus_async/_util.py
+++ b/src/prometheus_async/_util.py
@@ -29,6 +29,6 @@ def mk_get_time():
         return time.perf_counter
     except AttributeError:
         import monotonic
-        return monotonic.time
+        return monotonic.time.clock
 
 get_time = mk_get_time()


### PR DESCRIPTION
Hi there,

I'm trying to use this with python 2.7, and when time in _decorators.py tries to import get_time from utils it currently ends up with a module (module 'time' (built-in)),

I'm suggesting the use of time.clock which seems to be the closest thing in monotonic to python3's time.perf_counter. 

Many thanks,
Sorcha