### PR TITLE
Fix GitHub project URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ NAME = "prometheus_async"
 KEYWORDS = ["metrics", "prometheus", "twisted", "asyncio"]
 PROJECT_URLS = {
     "Documentation": "https://prometheus-async.readthedocs.io/",
-    "Bug Tracker": "https://github.com/hynek/prometheus-async/issues",
-    "Source Code": "https://github.com/hynek/prometheus-async",
+    "Bug Tracker": "https://github.com/hynek/prometheus_async/issues",
+    "Source Code": "https://github.com/hynek/prometheus_async",
 }
 
 CLASSIFIERS = [


### PR DESCRIPTION
This fixes the links on the left of the [the PyPI page](https://pypi.org/project/prometheus-async/)